### PR TITLE
add gtk3-mushrooms

### DIFF
--- a/pkgs
+++ b/pkgs
@@ -125,3 +125,4 @@
 - python-azure-storage
 - nohang-git
 - ungoogled-chromium-bin
+- gtk3-mushrooms


### PR DESCRIPTION
this replaces gtk3 and changes the "typing letters in directory" method to setting the cursor to the file corresponding to the typed letter instead of doing a full search